### PR TITLE
Fix errors in dcs.log

### DIFF
--- a/TheWay.lua
+++ b/TheWay.lua
@@ -118,12 +118,13 @@ function LuaExportAfterNextFrame()
     end
 
 
-  local camPos = LoGetCameraPosition()
+	local camPos = LoGetCameraPosition()
 	local loX = camPos['p']['x']
 	local loZ = camPos['p']['z']
 	local elevation = LoGetAltitude(loX, loZ)
 	local coords = LoLoCoordinatesToGeoCoordinates(loX, loZ)
-	local model = LoGetSelfData()["Name"];
+	local selfData = LoGetSelfData()
+	local model = selfData and selfData['Name'] or ''
 
 	local toSend = "{ ".."\"model\": ".."\""..model.."\""..", ".."\"coords\": ".. "{ ".."\"lat\": ".."\""..coords.latitude.."\""..", ".."\"long\": ".."\""..coords.longitude.."\"".."} "..", ".."\"elev\": ".."\""..elevation.."\"".."}"
 

--- a/src/main/java/main/Waypoints/WaypointManager.java
+++ b/src/main/java/main/Waypoints/WaypointManager.java
@@ -41,7 +41,7 @@ public class WaypointManager {
                 List<Point> av8bnaCoords = AV8BNA.getCoords(waypoints);
                 String dataToSend = AV8BNA.getCommands(av8bnaCoords).toString();
                 PortSender.send(dataToSend);
-            } else if(model.equals("Ka-50")) {
+            } else if(model.equals("Ka-50") || model.equals("Ka-50_3")) {
                 if(waypoints.size()>6){
                     GUI.error("The Ka-50 can store a maximum of 6 waypoints. ");
                 } else {


### PR DESCRIPTION
Eliminates the nil value errors in dcs.log:
2022-10-31 16:37:42.131 ERROR   Lua::Config (Main): Call error LuaExportAfterNextFrame:[string "TheWay.lua"]:126: attempt to index a nil value
stack traceback:
	[C]: ?
	[string "TheWay.lua"]:126: in function <[string "TheWay.lua"]:112>.
2022-10-31 16:37:53.944 WARNING LOG (11220): 884 duplicate message(s) skipped.

This change also allows capturing coordinates in multiplayer Spectator mode.