### PR TITLE
Fix dialog having transparent background

### DIFF
--- a/src/theme/TheWayTheme.js
+++ b/src/theme/TheWayTheme.js
@@ -8,7 +8,7 @@ const theWayTheme = {
     neutral: { main: grey[800] },
     background: {
       default: grey[900],
-      paper: grey[850],
+      paper: grey[900],
     },
   },
   typography: {


### PR DESCRIPTION
Fix #100 by changing `palette.background.paper` to a valid color.

Before:
![before](https://github.com/aronCiucu/DCSTheWay/assets/18213435/7054f75a-d227-4fc6-aa4c-545f67a96e37)

After:
![after](https://github.com/aronCiucu/DCSTheWay/assets/18213435/53237b0a-c104-421d-886a-362f6516a61b)
