### PR TITLE
Bugfix altitude for M-2000C

### DIFF
--- a/src/moduleCommands/m2000.js
+++ b/src/moduleCommands/m2000.js
@@ -134,8 +134,8 @@ class m2000{
                 device: 9,
                 code: 3574,
                 delay: 100,
-                activate: 1,
-                addDepress: "true",
+                activate: 0.3,
+                addDepress: "false",
             });
             this.#codesPayload.push(
                 {


### PR DESCRIPTION
Fixed a bug in the altitude selection for Mirage 2000C when transfering the waypoints.
The Parameter selection knob was set to "TR/VS" (wind) instead of "ALT" (altitude) after the Lat/Long transfer, so the altitude value was lost.