### PR TITLE
allow .json file import for interopability

### DIFF
--- a/electron/fileHandler.js
+++ b/electron/fileHandler.js
@@ -17,7 +17,7 @@ class FileHandler {
   openFile() {
     dialog
       .showOpenDialog({
-        filters: [{ name: "TheWay file", extensions: ["tw"] }],
+        filters: [{ name: "TheWay file", extensions: ["tw", "json"] }],
       })
       .then(({ filePaths }) => {
         if (filePaths.length === 1) {


### PR DESCRIPTION
update fileHandler.js to load json files
make it easier to interact with common json tools such as https://jsoneditoronline.org/